### PR TITLE
SQL export bug fix and always cleanup on script exit

### DIFF
--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -46,8 +46,6 @@ function cleanup() {
   fi
 }
 
-trap cleanup EXIT
-
 set -e
 
 command -v cut >/dev/null 2>&1 || {
@@ -144,6 +142,8 @@ gcloud sql instances create "$TARGET_BACKUP_INSTANCE" \
   --storage-type="$INSTANCE_STORAGE_TYPE" \
   --storage-size="$INSTANCE_STORAGE_SIZE_GB" \
   --database-version="$DB_VERSION"
+
+trap cleanup EXIT
 
 echo
 echo '==================================================================================================='


### PR DESCRIPTION
Fixes a bug on the sql export command that causes the script to exit early if the dump happens too quickly.
Also moves all of the cleanup code into an on exit trap.