### PR TITLE
Optionally export all databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The script requires some environment variables in order to function correctly:
 | Name        | Description   | Example |
 | ------------- |-------------|-------------|
 | DB_VERSION    | The version of the ephemeral database instance that'll be created | "POSTGRES_9_6" |
-| DB_NAME       | The database name that'll be exported to GCS | "my-db" |
+| DB_NAME       | The database name that'll be exported to GCS - if not specified all databases will be exported | "my-db" |
 | INSTANCE_CPU  | vCPUs of the ephemeral instance | "4" |
 | INSTANCE_ENV | Name of environment the backup process is running in. It's used in the ephemeral instance name | "nonprod" |
 | INSTANCE_MEM | Memory of instance | "7680MiB" |

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -24,7 +24,6 @@ command -v sed >/dev/null 2>&1 || { echo "sed is required"; invalid=true; }
 command -v tr >/dev/null 2>&1 || { echo "tr is required"; invalid=true; }
 
 [ -z "$DB_VERSION" ] && echo "DB_VERSION is required"; invalid=true
-[ -z "$DB_NAME" ] && echo "DB_NAME is required"; invalid=true
 [ -z "$INSTANCE_CPU" ] && echo "INSTANCE_CPU is required"; invalid=true
 [ -z "$INSTANCE_ENV" ] && echo "INSTANCE_ENV is required"; invalid=true
 [ -z "$INSTANCE_MEM" ] && echo "INSTANCE_MEM is required"; invalid=true


### PR DESCRIPTION
Leaving out the DB_NAME parameter now exports all databases on the instance