### PR TITLE
Move db delete to before bucket perm removal

### DIFF
--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -24,17 +24,6 @@ function cleanup() {
   echo
   echo '==================================================================================================='
   echo '|'
-  echo '| Revoking the new DB instance''s service account permission to write to GCS bucket'
-  echo '|'
-  echo '==================================================================================================='
-  echo
-
-  echo_out "Removing write access on $TARGET_BACKUP_BUCKET for $DB_SA_ID"
-  gsutil acl ch -d "$DB_SA_ID" "$TARGET_BACKUP_BUCKET"
-
-  echo
-  echo '==================================================================================================='
-  echo '|'
   echo '| Deleting new ephemeral DB instance'
   echo '|'
   echo '==================================================================================================='
@@ -46,6 +35,17 @@ function cleanup() {
   else
     echo_out "String 'backup' not detected in target backup instance. Not deleting anything.."
   fi
+
+  echo
+  echo '==================================================================================================='
+  echo '|'
+  echo '| Revoking the new DB instance''s service account permission to write to GCS bucket'
+  echo '|'
+  echo '==================================================================================================='
+  echo
+
+  echo_out "Removing write access on $TARGET_BACKUP_BUCKET for $DB_SA_ID"
+  gsutil acl ch -d "$DB_SA_ID" "$TARGET_BACKUP_BUCKET"
 }
 
 set -e
@@ -189,7 +189,7 @@ while :; do
     break
   fi
   if [[ $NUM_CHECKS == "$MAX_CHECKS" ]]; then
-    echo_out "Reached check limit ($MAX_CHECKS). This is a failure, aborting"
+    echo_out "Reached check limit ($MAX_CHECKS). Aborting, but the 'gcloud sql export sql' op may still be in progress"
     break
   fi
   echo_out "Backup file not found in bucket, checking again in $SLEEP_SECONDS seconds"


### PR DESCRIPTION
This essentially switches the order of the db delete + removal of GCS bucket perm

The reason for this is pretty nuanced... If the process of polling GCS to see if the backup file has appeared reaches the end (as defined by the `MAX_CHECKS` var), the `cleanup()` function was attempting first to remove the GCS bucket perms with:

```
gsutil acl ch -d "$DB_SA_ID" "$TARGET_BACKUP_BUCKET"
```

...before then proceeding to attempt to delete the database.

The perm removal was succeeding, but was then causing the export process (that's still running; the reason why the backup file hasn't appeared in GCS yet...) to fail with:

> failed to upload data to GCS URL gs://orex-postgresbackup-prod/postgres-backup-prod-20191112103012-1573549200399-b999v.gz: +Access denied for account p435486835458-bsqtm0@gcp-sa-cloud-sql.iam.gserviceaccount.com (permission issue?) Access denied for account p435486835458-bsqtm0@gcp-sa-cloud-sql.iam.gserviceaccount.com (permission issue?)

...so the export process has now failed due to the perm removal.

With the new order:

```
gcloud -q sql instances delete "$TARGET_BACKUP_INSTANCE"
...
gsutil acl ch -d "$DB_SA_ID" "$TARGET_BACKUP_BUCKET"
```

...the attempt to delete the database will fail with:

> ERROR: (gcloud.sql.instances.delete) HTTPError 409: Operation failed because another operation was already in progress.

..and the export process will continue in the background afterwards.



To summarise, with this change the user is still left with a database instance, but the export process doesn't get killed off. The perm for the service account GCP have created will still be present on the GCS bucket, but I don't see any way round that.
