### PR TITLE
Improve reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,12 @@ The script requires some environment variables in order to function correctly:
 
 | Name        | Description   | Example |
 | ------------- |-------------|-------------|
-| DB_VERSION    | The version of the ephemeral database instance that'll be created | "POSTGRES_9_6" |
 | DB_NAME       | The database name that'll be exported to GCS | "my-db" |
 | INSTANCE_CPU  | vCPUs of the ephemeral instance | "4" |
 | INSTANCE_ENV | Name of environment the backup process is running in. It's used in the ephemeral instance name | "nonprod" |
 | INSTANCE_MEM | Memory of instance | "7680MiB" |
 | INSTANCE_NAME_PREFIX | Prefix to add to the start of instance name | "my-backup" |
 | INSTANCE_REGION | Instance region | "europe-west1" |
-| INSTANCE_STORAGE_SIZE_GB | Disk storage capacity (must be greater than the capacity of the original instance the GCP back is taken from) | "4000" |
 | INSTANCE_STORAGE_TYPE | SSD (default) or HDD | "SSD" |
 | PROJECT | The GCP project | "my-gcp-project" |
 | SA_KEY_FILEPATH | The path to the GCP service account's .json key | "/secrets/gcp/backup-key.json" |


### PR DESCRIPTION
This is a PR to improve the reliability of the backup script by:
- Using the source backup instance to set the database version and instance storage size; and
- Ensuring that each operation on the target instance is complete before starting another.

#### Motivation

After moving to `v0.6` and integrating with DataDog, we noticed that some of our backups would fail every few weeks.

It wasn't clear from the logs what the issue was, but after an investigation, we discovered that the response to `gcloud -q sql backups restore` was:
```
ERROR: (gcloud.sql.backups.restore) HTTPError 400: This operation isn"t valid for this instance.
```

Our backups are managed by Terraform, with the value of `INSTANCE_STORAGE_SIZE_GB` taken directly from GCP. We had also noticed the value of `INSTANCE_STORAGE_SIZE_GB` changing fairly regularly  in our Terraform execution plans, and this led us to realise that the backups had been failing due to the value of `INSTANCE_STORAGE_SIZE_GB` being less than storage size of the source instance.

In addition to this, when the backups failed,  the target instances were not being deleted and were accumulating quickly. This was a result of the export operation still being attempted after the failed restore, and export not having finished before trying to delete the target instance. The response to `gcloud -q sql instances delete` was:
```
ERROR: (gcloud.sql.instances.delete) HTTPError 409: Operation failed because another operation was already in progress.
```

#### Changes

I have based the changes on our experience and the [tips and requirements for restoring an instance](https://cloud.google.com/sql/docs/postgres/backup-recovery/restore#tips-restore-different-instance).

1. Use values taken directly from the source instance for `DB_VERSION` and `INSTANCE_STORAGE_SIZE_GB` to ensure that they are always correct.
2. Ensure that the target instance state is `RUNNABLE` before restoring to it.
3. Poll to see if the restore is complete rather than just waiting 10 minutes.
4. Ensure that all operations on the target instance are complete before attempting to delete it.

#### Testing

I've tested the script by running it locally. The happy path works as expected and I've also confirmed that the target instance is deleted when something goes wrong.

Any feedback would be greatly appreciated!