### PR TITLE
Add CICD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,28 @@ jobs:
             docker build -t ovotech/cloud_sql_backup:latest .
             echo $DOCKER_PASS | docker login -u=$DOCKER_USER --password-stdin
             docker push ovotech/cloud_sql_backup
+  test_backup:
+    <<: *defaults
+
+    docker:
+      - image: google/cloud-sdk
+
+    steps:
+     - checkout
+
+     - run:
+         name: "Run backup script"
+         command: |
+           echo "$GOOGLE_CREDENTIALS" > /tmp/google_creds
+           export DB_NAME=test-db-1
+           export INSTANCE_CPU=1
+           export INSTANCE_ENV=cicd
+           export INSTANCE_MEM=3840MiB
+           export INSTANCE_NAME_PREFIX=cloud-sql-backup
+           export INSTANCE_REGION=europe-west1
+           export INSTANCE_STORAGE_TYPE=SSD
+           export SA_KEY_FILEPATH=/tmp/google_creds
+           ./cloud_sql_backup.sh
 
 workflows:
   version: 2
@@ -39,3 +61,18 @@ workflows:
   shellcheck:
     jobs:
       - shellcheck/check
+  pr_pipelines:
+    jobs:
+      - test_backup:
+          filters:
+            branches:
+              ignore: master
+  nightly_master_check:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - test_backup

--- a/README.md
+++ b/README.md
@@ -136,3 +136,12 @@ Whilst it's recommended to monitor for failed/successful `cloud_sql_backup.sh` s
 ### Completion Check
 
 The penultimate task of the `cloud_sql_backup.sh` script is to poll GCS using `gsutil` to verify the object (SQL dump) has arrived in GCS as expected. This has to be performed out-of-band of the SQL dump process, as the dump is an operation that's triggered on the ephemeral db instance (using `gcloud sql export sql`).
+
+
+## Contributions
+
+Contributions are very welcome. Please branch or fork, and submit a PR.
+
+PRs from branches will result in an e2e test being run in CircleCI, which can
+sometimes take around 15mins. Commits from forked PRs should be made onto a
+branch in this repo, and another PR opened so the e2e test can run.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The script requires some environment variables in order to function correctly:
 | DB_NAME       | The database name that'll be exported to GCS | "my-db" |
 | INSTANCE_CPU  | vCPUs of the ephemeral instance | "4" |
 | INSTANCE_ENV | Name of environment the backup process is running in. It's used in the ephemeral instance name | "nonprod" |
-| INSTANCE_MEM | Memory of instance | "7680MiB" |
+| INSTANCE_MEM | Memory of instance (multiple of 256 MiB, min 3840MiB) | "7680MiB" |
 | INSTANCE_NAME_PREFIX | Prefix to add to the start of instance name | "my-backup" |
 | INSTANCE_REGION | Instance region | "europe-west1" |
 | INSTANCE_STORAGE_TYPE | SSD (default) or HDD | "SSD" |
@@ -89,6 +89,12 @@ When this script runs using a GCP service account, it'll need a specific set of 
     "storage.objects.get"
   ]
   ```
+
+The service account must have OWNER-role access to the `TARGET_BACKUP_BUCKET`.
+GCP creates a temporary service account during the export process, which needs
+to be able to write to your GCS bucket. The service account you provide needs
+enough permission to elevate the temporary service account's permissions on the
+bucket (they get revoked again after being used).
 
 ## Notes
 

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -292,7 +292,7 @@ echo_out "Creating SQL backup file of instance: $TARGET_BACKUP_INSTANCE and expo
 export_rs=$(gcloud sql export sql "$TARGET_BACKUP_INSTANCE" "$TARGET_BACKUP_URI" \
   --database="$DB_NAME" 2>&1 || true)
 
-if [[ $export_rs != *"sql operations wait"* ]] && [[ $export_rs != *"done"* ]]; then
+if [[ $export_rs != *"sql operations wait"* ]] && [[ $export_rs != *"done"* ]] && [[ $export_rs != *"Exported"* ]]; then
   echo_out "Unexpected response returned for 'gcloud sql export sql...' command: $export_rs"
   exit 1
 fi


### PR DESCRIPTION
- CI/CD with a PR and scheduled nightly checks
- readme updates
- added an additional valid result of the `gcloud sql export sql` command: `[[ $export_rs != *"Exported"* ]]`. This happens when the database/backup is so small there's no waiting involved (it happens in the e2e tests as it's a tiny db)