### PR TITLE
Allow multiple databases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
          name: "Run backup script"
          command: |
            echo "$GOOGLE_CREDENTIALS" > /tmp/google_creds
-           export DB_NAME=test-db-1
+           export DB_NAME=test-db-1:test-db-2
            export INSTANCE_CPU=1
            export INSTANCE_ENV=cicd
            export INSTANCE_MEM=3840MiB

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ name = <instance_name_prefix>-<instance_env>-<timestamp>-<gcp_managed_backup_id>
 - `gcp_managed_backup_id` is the ID of the latest GCP managed backup
 - `random_string` is the value of `LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 5`
 
+The `.gz` file that gets written to GCS will also have the db name as the last element before the file extension.
+
 ### Backup candidate
 
 The ID of the latest successful GCP managed backup is obtained using:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The script requires some environment variables in order to function correctly:
 
 | Name        | Description   | Example |
 | ------------- |-------------|-------------|
-| DB_NAME       | The database name that'll be exported to GCS | "my-db" |
+| DB_NAME (colon separated)      | The database name(s) that'll be exported to GCS | "my-db" or "my-db-1:my-db-2"|
 | INSTANCE_CPU  | vCPUs of the ephemeral instance | "4" |
 | INSTANCE_ENV | Name of environment the backup process is running in. It's used in the ephemeral instance name | "nonprod" |
 | INSTANCE_MEM | Memory of instance (multiple of 256 MiB, min 3840MiB) | "7680MiB" |

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -53,9 +53,9 @@ function all_operations_have_finished() {
   completed_operations=$(echo "$operation_details" | grep "DONE" -c)
 
   if [[ "${completed_operations}" -lt "${number_of_operations}" ]]; then
-    echo 0
+    echo "0"
   else
-    echo 1
+    echo "1"
   fi
 }
 
@@ -63,11 +63,11 @@ function wait_for_target_instance_to_be_created() {
   local NUM_CHECKS=0
   local MAX_CHECKS=10
   local SLEEP_SECONDS=30
-  echo_out "Polling GCP to check the new instance is runnable: $TARGET_BACKUP_INSTANCE (max_checks: $NUM_CHECKS, sleep_interval(s): $SLEEP_SECONDS)"
+  echo_out "Polling GCP to check the new instance is runnable: $TARGET_BACKUP_INSTANCE (max_checks: $MAX_CHECKS, sleep_interval(s): $SLEEP_SECONDS)"
 
   while :; do
-    ((NUM_CHECKS++))
-    if [[ $(target_instance_is_runnable) == *"1"* ]]; then
+    ((NUM_CHECKS+=1))
+    if [[ "$(target_instance_is_runnable)" == "1" ]]; then
       echo_out "Target instance is runnable"
       break
     fi
@@ -84,11 +84,11 @@ function wait_for_restore_to_finish() {
   local NUM_CHECKS=0
   local MAX_CHECKS=10
   local SLEEP_SECONDS=60
-  echo_out "Polling GCP to check whether restore to target instance has finished: $TARGET_BACKUP_INSTANCE (max_checks: $NUM_CHECKS, sleep_interval(s): $SLEEP_SECONDS)"
+  echo_out "Polling GCP to check whether restore to target instance has finished: $TARGET_BACKUP_INSTANCE (max_checks: $MAX_CHECKS, sleep_interval(s): $SLEEP_SECONDS)"
 
   while :; do
-    ((NUM_CHECKS++))
-    if [[ $(operation_has_finished "RESTORE_VOLUME") == *"1"* ]]; then
+    ((NUM_CHECKS+=1))
+    if [[ "$(operation_has_finished "RESTORE_VOLUME")" == "1" ]]; then
       echo_out "Restore has finished."
       break
     fi
@@ -105,11 +105,11 @@ function wait_for_all_operations_to_finish() {
   local NUM_CHECKS=0
   local MAX_CHECKS=10
   local SLEEP_SECONDS=60
-  echo_out "Polling GCP to check whether all operations on target instance have finished: $TARGET_BACKUP_INSTANCE (max_checks: $NUM_CHECKS, sleep_interval(s): $SLEEP_SECONDS)"
+  echo_out "Polling GCP to check whether all operations on target instance have finished: $TARGET_BACKUP_INSTANCE (max_checks: $MAX_CHECKS, sleep_interval(s): $SLEEP_SECONDS)"
 
   while :; do
-    ((NUM_CHECKS++))
-    if [[ $(all_operations_have_finished) == *"1"* ]]; then
+    ((NUM_CHECKS+=1))
+    if [[ "$(all_operations_have_finished)" == "1" ]]; then
       echo_out "All operations have finished."
       break
     fi
@@ -315,7 +315,7 @@ echo_out "Polling GCS to check the new object exists: $TARGET_BACKUP_URI (max_ch
 # disable non-zero status exit so 'gsutil -q stat' doesn't throw us out
 set +e
 while :; do
-  ((NUM_CHECKS++))
+  ((NUM_CHECKS+=1))
   if gsutil -q stat "$TARGET_BACKUP_URI"; then
     echo_out "Object found in bucket"
     success=1

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -288,7 +288,10 @@ echo '|'
 echo '==================================================================================================='
 echo
 
+echo_out "Picked up database names from env: $DB_NAMES"
+
 for db in ${DB_NAME//,/ } ; do
+    echo_out "Processing database: $db"
     ((database_count++))
     TARGET_BACKUP_URI=$TARGET_BACKUP_BUCKET/${TARGET_BACKUP_INSTANCE}_$db.gz
     echo_out "Creating SQL backup file of instance: $TARGET_BACKUP_INSTANCE and exporting to $TARGET_BACKUP_URI"

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -288,12 +288,12 @@ echo '|'
 echo '==================================================================================================='
 echo
 
-echo_out "Picked up database names from env: $DB_NAMES"
+echo_out "Picked up database names from env: $DB_NAME"
 
 for db in ${DB_NAME//,/ } ; do
     echo_out "Processing database: $db"
     ((database_count++))
-    TARGET_BACKUP_URI=$TARGET_BACKUP_BUCKET/${TARGET_BACKUP_INSTANCE}_$db.gz
+    TARGET_BACKUP_URI="$TARGET_BACKUP_BUCKET/${TARGET_BACKUP_INSTANCE}_$db.gz"
     echo_out "Creating SQL backup file of instance: $TARGET_BACKUP_INSTANCE and exporting to $TARGET_BACKUP_URI"
     export_rs=$(gcloud sql export sql "$TARGET_BACKUP_INSTANCE" "$TARGET_BACKUP_URI" \
       --database="$db" 2>&1 || true)

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -290,7 +290,7 @@ echo
 
 echo_out "Picked up database names from env: $DB_NAME"
 
-for db in ${DB_NAME//,/ } ; do
+for db in ${DB_NAME//:/ } ; do
     echo_out "Processing database: $db"
     database_count=$((database_count + 1))
     TARGET_BACKUP_URI="$TARGET_BACKUP_BUCKET/${TARGET_BACKUP_INSTANCE}_$db.gz"

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -292,7 +292,7 @@ echo_out "Picked up database names from env: $DB_NAME"
 
 for db in ${DB_NAME//,/ } ; do
     echo_out "Processing database: $db"
-    ((database_count++))
+    database_count=$((database_count + 1))
     TARGET_BACKUP_URI="$TARGET_BACKUP_BUCKET/${TARGET_BACKUP_INSTANCE}_$db.gz"
     echo_out "Creating SQL backup file of instance: $TARGET_BACKUP_INSTANCE and exporting to $TARGET_BACKUP_URI"
     export_rs=$(gcloud sql export sql "$TARGET_BACKUP_INSTANCE" "$TARGET_BACKUP_URI" \


### PR DESCRIPTION
Adds the ability to export multiple databases

The list of database names is obtained by colon splitting the `DB_NAME` env var

..so the following steps have been moved into a for loop of databases:

- `gcloud sql export sql` cmd
- polling GCS for arrival of `.gz`

for metrics/monitoring, the whole backup process is only considered a success if `"$success_count" -eq "$database_count"`(success_count is incremented when the object is verified in GCS, database_count is incremented on each iteration of the loop).

this has been tested (via CI/CD) with both single and multiple databases defined in `DB_NAME`

worth noting, database name will now appear in the filename, but that seems fine with all users I've checked with.