### PR TITLE
Add --require-ssl flag

### DIFF
--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -240,7 +240,8 @@ gcloud sql instances create "$TARGET_BACKUP_INSTANCE" \
   --region="$INSTANCE_REGION" \
   --storage-type="$INSTANCE_STORAGE_TYPE" \
   --storage-size="$INSTANCE_STORAGE_SIZE_GB" \
-  --database-version="$DB_VERSION"
+  --database-version="$DB_VERSION" \
+  --require-ssl
 echo
 
 trap cleanup EXIT


### PR DESCRIPTION
We (Orex) had an Infosec alert that fired due to one of our ephemeral databases was detected as not requiring SSL for users that connect to it. Seeing as there shouldn't be any users connecting the ephemeral DBs, I thought we may as well just enable it.