### PR TITLE
AE-1372: add sql export timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM google/cloud-sdk:319.0.0-alpine
 ADD cloud_sql_backup.sh cloud_sql_backup.sh
 RUN gcloud components install beta -q
 
+RUN apk add jq
+
 RUN addgroup -S csbgroup  && adduser -S csbuser -G csbgroup
 RUN chown csbuser:csbgroup cloud_sql_backup.sh
 USER csbuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM google/cloud-sdk:319.0.0-alpine
 
 ADD cloud_sql_backup.sh cloud_sql_backup.sh
+RUN gcloud components install beta -q
 
 RUN addgroup -S csbgroup  && adduser -S csbuser -G csbgroup
 RUN chown csbuser:csbgroup cloud_sql_backup.sh

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+set -e
 
 function echo_out() {
   echo -e "[$(date +%F_%T)] $1"

--- a/cloud_sql_backup.sh
+++ b/cloud_sql_backup.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
+
 function echo_out() {
-  echo "[$(date +%F_%T)] $1"
+  echo -e "[$(date +%F_%T)] $1"
 }
 
 function post_count_metric() {
@@ -181,6 +183,8 @@ command -v tr >/dev/null 2>&1 || { echo "tr is required" && invalid=true; }
 [ -z "$SA_KEY_FILEPATH" ] && echo "SA_KEY_FILEPATH is required" && invalid=true
 [ -z "$SOURCE_BACKUP_INSTANCE" ] && echo "SOURCE_BACKUP_INSTANCE is required" && invalid=true
 [ -z "$TARGET_BACKUP_BUCKET" ] && echo "TARGET_BACKUP_BUCKET is required" && invalid=true
+# default timeout for sql export: 3 hours
+[ -z "$TIMEOUT" ] && TIMEOUT=10800
 
 if [ "$invalid" = true ] ; then
     exit 1
@@ -296,13 +300,65 @@ for db in ${DB_NAME//:/ } ; do
     database_count=$((database_count + 1))
     TARGET_BACKUP_URI="$TARGET_BACKUP_BUCKET/${TARGET_BACKUP_INSTANCE}_$db.gz"
     echo_out "Creating SQL backup file of instance: $TARGET_BACKUP_INSTANCE and exporting to $TARGET_BACKUP_URI"
-    export_rs=$(gcloud sql export sql "$TARGET_BACKUP_INSTANCE" "$TARGET_BACKUP_URI" \
-      --database="$db" 2>&1 || true)
 
-    if [[ $export_rs != *"sql operations wait"* ]] && [[ $export_rs != *"done"* ]] && [[ $export_rs != *"Exported"* ]]; then
-      echo_out "Unexpected response returned for 'gcloud sql export sql...' command: $export_rs"
-      exit 1
-    fi
+    set +e
+
+    gcloud sql export sql "$TARGET_BACKUP_INSTANCE" "$TARGET_BACKUP_URI" \
+	--database="$db" > /tmp/sql-export.log 2>&1
+    EXIT_CODE=$?
+    echo_out "SQL export exit code: $EXIT_CODE"
+
+    set -e
+
+    cat /tmp/sql-export.log
+
+    # check if there's any error
+    [[ $EXIT_CODE -ne 0 ]] && {
+        SQL_EXPORT_LOGS="$(cat /tmp/sql-export.log)"
+
+	echo_out "Unexpected response returned for 'gcloud sql export sql:\n$SQL_EXPORT_LOGS"
+
+	# it's a long-running job, need to extend the waiting time
+        [[ $SQL_EXPORT_LOGS =~ "is taking longer than expected. You can continue waiting for the operation by running" ]] && {
+
+	    # we need to wait no longer,
+	    # extract the command to wait for the job to finish
+            WAIT_ARGS="$(echo $SQL_EXPORT_LOGS | \
+            tail -1 | \
+            sed -r 's/.*gcloud beta sql operations wait --project (.*)`/\1/')"
+	    IFS=' ' read -r -a ARGS_ARRAY <<< "$WAIT_ARGS"
+	    GCP_PROJECT="${ARGS_ARRAY[0]}"
+	    UUID="${ARGS_ARRAY[1]}"
+
+	    echo_out "Waiting for export job to finish"
+
+	    # validate UUID
+	    if [[ ! ${UUID//-/} =~ ^[[:xdigit:]]{32}$ ]];
+	    then
+		echo_out "Invalid job number, not a UUID"
+	        exit 1
+	    fi
+
+	    # validate project name
+	    if [[ "$PROJECT" != "$GCP_PROJECT" ]];
+	    then
+	        echo_out "Unexpected project name"
+	        exit 1
+	    fi
+	    # wait for the operation to finish,
+	    # but set a timeout
+            gcloud beta sql operations wait \
+		--timeout=$TIMEOUT \
+		--project "$GCP_PROJECT" "$UUID"
+        } || {
+
+	    # nothing we can do, export failed
+	    exit 1
+        }
+    }
+
+    rm -f /tmp/sql-export.log
+
 
     echo
     echo '==================================================================================================='


### PR DESCRIPTION
When a db instance has many GB (or better TB) to transfer, the SQL export command below fails after ~10 minutes:

```
gcloud sql export sql "$TARGET_BACKUP_INSTANCE" "$TARGET_BACKUP_URI" --database="$db"
```

Using the `--async` flag we get back the job URL, so that we can check what's the status by polling every 5 minutes.

Using the above command asynchronously we can wait for more time for a db backup to finish.
Timeout is specified in seconds and its default is 3 hours.
